### PR TITLE
fix: checkout a specific version from repo

### DIFF
--- a/yolo_image_src/Dockerfile
+++ b/yolo_image_src/Dockerfile
@@ -2,6 +2,7 @@ FROM autoware/model-zoo-tvm-cli:1.0.0
 RUN apt update && apt install git-lfs
 WORKDIR /app
 RUN GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/autowarefoundation/modelzoo && \
+    git checkout 0da13b81bac1bdca34f72c037033d605105fce49 && \
     cd modelzoo && \
     git lfs install && \
     git lfs pull


### PR DESCRIPTION
Changed on the upstream repo has broken the build. Cloning a specific version.